### PR TITLE
Fix “Create tag” action prompts for not having access to the repository.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,9 +57,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
       - name: Create tag
-        run: |
-           git tag ${{needs.build.outputs.version}}
-           git push origin ${{needs.build.outputs.version}}
+        uses: rickstaa/action-create-tag@v1
+        id: "tag_create"
+        with:
+          tag: "${{needs.build.outputs.version}}"
+          tag_exists_error: true
+          message: "Created tag ${{needs.build.outputs.version}}"
       - name: Get repository name
         run: |
           echo "REPOSITORY_NAME=${GITHUB_REPOSITORY#${GITHUB_REPOSITORY_OWNER}/}" >> $GITHUB_ENV


### PR DESCRIPTION
### Changes: 

- Modify the “Create tag” action in “release.yml” to solve the problem of not having access to the repository during process.